### PR TITLE
migrates package to not use deprecated methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
   },
   "homepage": "https://github.com/zlargon/react-highlight#readme",
   "dependencies": {
-    "highlight.js": "^9.10.0"
+    "create-react-class": "^15.6.0",
+    "highlight.js": "^9.10.0",
+    "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "react": "15.x",
-    "react-dom": "15.x"
+    "react": "^15.5.0",
+    "react-dom": "^15.x"
   }
 }

--- a/react-highlight.js
+++ b/react-highlight.js
@@ -17,9 +17,14 @@
     window.HighLight = window.HighLight || factory(React, ReactDOM, hljs);
   }
 
-})(function (React, ReactDOM, hljs) {
-  var HighLightClass = createReactClass({
-        componentDidMount: function () {
+})(function (React, ReactDOM, PropTypes, hljs, createReactClass) {
+  return createReactClass({
+    propTypes: {
+      lang: React.PropTypes.string.isRequired,
+      value: React.PropTypes.string.isRequired
+    },
+
+    componentDidMount: function () {
       // this will only be called once after first time render
       this.updateCodeBlockDOM();
     },
@@ -66,10 +71,5 @@
     }
   });
 
-  HighLightClass.propTypes = {
-    lang: React.PropTypes.string.isRequired,
-    value: React.PropTypes.string.isRequired
-  };
 
-  return HighLightClass;
 });

--- a/react-highlight.js
+++ b/react-highlight.js
@@ -8,7 +8,9 @@
     module.exports = factory(
       require('react'),
       require('react-dom'),
-      require('highlight.js')
+      require('prop-types'),
+      require('highlight.js'),
+      require('create-react-class')
     );
   } else {
     // Browser: export as global variable
@@ -16,13 +18,8 @@
   }
 
 })(function (React, ReactDOM, hljs) {
-  return React.createClass({
-    propTypes: {
-      lang: React.PropTypes.string.isRequired,
-      value: React.PropTypes.string.isRequired
-    },
-
-    componentDidMount: function () {
+  var HighLightClass = createReactClass({
+        componentDidMount: function () {
       // this will only be called once after first time render
       this.updateCodeBlockDOM();
     },
@@ -68,4 +65,11 @@
       }
     }
   });
+
+  HighLightClass.propTypes = {
+    lang: React.PropTypes.string.isRequired,
+    value: React.PropTypes.string.isRequired
+  };
+
+  return HighLightClass;
 });


### PR DESCRIPTION
Access to createClass and propTypes are deprecated in React 15 and will be removed. This change undeprecates the package by adding `create-react-class` and `prop-types` packages into the implementation.

```
 console.warn node_modules/react/lib/lowPriorityWarning.js:40
    Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class

  console.warn node_modules/react/lib/lowPriorityWarning.js:40
    Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs
```